### PR TITLE
new https iplookup api

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,7 +1,7 @@
 var weatherAt = ''
 
 function ipLookUp () {
-  $.ajax('http://ip-api.com/json')
+  $.ajax('https://ipinfo.io/json')
   .then(
       function success(response) {
           weatherAt = (`${response.city},${response.region}`);


### PR DESCRIPTION
Old API used an http url that causes a mixed content error in the deployed version. New API uses https eliminating the problem.